### PR TITLE
Deployment with docker to use gvfits and listscan without libraries problems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,59 @@
+FROM ubuntu:focal
+LABEL maintainer="mparra@iaa.es"
+
+# use bash instead of default sh
+
+SHELL ["/bin/bash", "-c"] 
+ENV APP_HOME /root
+WORKDIR ${APP_HOME}
+ENV DEBIAN_FRONTEND noninteractive
+
+# run apt-get
+
+RUN apt-get update && \
+    apt-get dist-upgrade -y && \
+    apt-get install --no-install-recommends -y \
+        python3-pip wget python-is-python3 \
+        libtinfo5 libquadmath0 git \
+        && \
+    apt-get autoremove -y && \ 
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install --upgrade pip packaging && \
+    rm -rf ./.cache/pip
+
+#RUN git clone https://github.com/r-xue/casa6-docker.git
+
+#RUN echo "Installing CASA6... may take a while in the container ..." && \
+#    python3   casa6-docker/casa6_install/casa6_install.py --core --no-deps && pip3 install numpy && pip3 list && \
+#    rm -rf ./.cache/pip /tmp/* /var/tmp/*
+
+RUN wget http://archive.ubuntu.com/ubuntu/pool/universe/g/gcc-6/libgfortran3_6.4.0-17ubuntu1_amd64.deb && \
+    dpkg-deb -c libgfortran3_6.4.0-17ubuntu1_amd64.deb && \ 
+    dpkg-deb -R libgfortran3_6.4.0-17ubuntu1_amd64.deb / && \
+    rm -rf ./libgfortran3_6.4.0-17ubuntu1_amd64.deb /DEBIAN
+
+RUN rm -rf \
+        ./.cache/pip \
+        /var/lib/apt/lists/* \
+        /tmp/* /var/tmp/*
+
+RUN apt-get update && \
+    apt-get dist-upgrade -y && \
+    apt-get install --no-install-recommends -y \
+        nano less wget git gcc python3-dev \
+        # gfortran build-essential make \
+        # cython3 \
+        # libfftw3-dev numdiff python3-pybind11 \
+        && \
+    apt-get autoremove -y && \     
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/ruta-k/CAPTURE-CASA6.git
+
+WORKDIR /root/CAPTURE-CASA6
+RUN chmod a+x listscan gvfits && mv * /usr/sbin/
+ENV PATH="/root/CAPTURE-CASA6:${PATH}"
+

--- a/README.md
+++ b/README.md
@@ -34,3 +34,32 @@ CAVEATS for CAPTURE:
 5. Primary beam correction: The images produced by the pipeline are not corrected for the effect of the primary beam. You need to run the primary beam correction separately. The CASA 6 compatible task “ugmrtpb” should be used. The instructions to use this task are provided in the documentation for the same.
 6. The data files where the primary and secondary calibrators are not named in the standard IAU format, CAPTURE will fail. It can be used after renaming the calibrators.
 7. CAPTURE can run when the primary calibrator is used as a secondary calibrator and no phase calibrator scan exists in the file. In such a case the primary calibrator with maximum number of scans will be considered the phase calibrator. If there is a combination of a secondary calibrator and a flux calibrator used for phase calibration of the target source, then CAPTURE will recognise only the phase calibrator scans as secondary calibrator and run.  
+
+
+## To use gvfits and listscan from a docker deployment
+
+### Docker
+
+Clone this repository:
+
+```
+git clone https://github.com/ruta-k/CAPTURE-CASA6.git
+```
+
+then: 
+
+```
+cd CAPTURE-CASA6
+docker build . -t capture-casa6
+```
+
+Run ``gvfits`` and ``listscan``:
+
+```
+docker run -it  $(PWD):/tmp/ capture-casa6  listscan <filename>
+#or
+docker run -it  $(PWD):/tmp/ capture-casa6  gvfits <filename>
+```
+
+
+


### PR DESCRIPTION
Hi, we had to use gvfits and listscan in different environments and SO's. We had problems running both commands, so we created a Dockerfile that allow us to run both utilities using docker and singularity in our pipelines. So, this is our contribution to solve the problem with dependencies and libraries of gvfits and listscan in modern SO's.
Regards,
Manu.